### PR TITLE
docs: add entity type filter to in-memory example

### DIFF
--- a/_example/cmd/database/others.go
+++ b/_example/cmd/database/others.go
@@ -53,10 +53,6 @@ func (db *Database) ListUserResources(entityType *string) []resources.Resource {
 	defer db.mutex.RUnlock()
 	db.Load()
 
-	if entityType == nil {
-		return db.Resources
-	}
-
 	// Create a map of resources by flattening the hierarchical data structure.
 	leaves := append([]resources.Resource{}, db.Resources...)
 	m := map[resources.Resource]resources.Resource{}
@@ -81,7 +77,7 @@ func (db *Database) ListUserResources(entityType *string) []resources.Resource {
 
 	result := []resources.Resource{}
 	for _, resource := range m {
-		if resource.Entity.Type == *entityType {
+		if entityType == nil || resource.Entity.Type == *entityType {
 			result = append(result, resource)
 		}
 	}

--- a/_example/cmd/service/resources.go
+++ b/_example/cmd/service/resources.go
@@ -45,6 +45,5 @@ func (s *ResourcesService) ListResources(ctx context.Context, params *resources.
 	//    return nil, v1.NewAuthorizationError("user cannot add group")
 	//
 
-	return Paginate(s.Database.ListUserResources(), params.Size, params.Page, params.NextToken, params.NextPageToken, false)
-
+	return Paginate(s.Database.ListUserResources(params.EntityType), params.Size, params.Page, params.NextToken, params.NextPageToken, false)
 }

--- a/_example/test.sh
+++ b/_example/test.sh
@@ -200,6 +200,8 @@ done
 
 echo -n 'GET resources: '
 curl $_opts -X GET "$_base/resources"
+echo -n 'GET resources: '
+curl $_opts -X GET "$_base/resources?entityType=foo"
 echo -n 'GET entitlements: '
 curl $_opts -X GET "$_base/entitlements"
 echo -n 'GET entitlements/raw: '


### PR DESCRIPTION
This PR adds a missing feature to the in-memory example, which is filtering resources by their entity type.

Fixes CSS-9682