### PR TITLE
fix: fix panic when a `*Service` interface is not implemented 

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,10 @@
 {
-  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
-  "include-component-in-tag": true,
-  "packages": {".": {  "release-as": "0.1.0"}}
+    "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+    "release-type": "go",
+    "include-component-in-tag": true,
+    "packages": {
+        ".": {
+            "initial-version": "0.1.0"
+        }
+    }
 }

--- a/v1/core.go
+++ b/v1/core.go
@@ -64,28 +64,58 @@ type ReBACAdminBackend struct {
 // NewReBACAdminBackend returns a new ReBACAdminBackend instance, configured
 // with given backends.
 func NewReBACAdminBackend(params ReBACAdminBackendParams) (*ReBACAdminBackend, error) {
+	identities := params.Identities
+	if identities == nil {
+		identities = unimplementedIdentitiesService{}
+	}
+
+	entitlements := params.Entitlements
+	if entitlements == nil {
+		entitlements = unimplementedEntitlementsService{}
+	}
+
+	groups := params.Groups
+	if groups == nil {
+		groups = unimplementedGroupsService{}
+	}
+
+	identityProviders := params.IdentityProviders
+	if identityProviders == nil {
+		identityProviders = unimplementedIdentityProvidersService{}
+	}
+
+	resources := params.Resources
+	if resources == nil {
+		resources = unimplementedResourcesService{}
+	}
+
+	roles := params.Roles
+	if roles == nil {
+		roles = unimplementedRolesService{}
+	}
+
 	return newReBACAdminBackendWithService(
 		params,
 		newHandlerWithValidation(&handler{
-			Identities:            params.Identities,
+			Identities:            identities,
 			IdentitiesErrorMapper: params.IdentitiesErrorMapper,
 
-			Roles:            params.Roles,
+			Roles:            roles,
 			RolesErrorMapper: params.RolesErrorMapper,
 
-			IdentityProviders:            params.IdentityProviders,
+			IdentityProviders:            identityProviders,
 			IdentityProvidersErrorMapper: params.IdentityProvidersErrorMapper,
 
 			Capabilities:            params.Capabilities,
 			CapabilitiesErrorMapper: params.CapabilitiesErrorMapper,
 
-			Entitlements:            params.Entitlements,
+			Entitlements:            entitlements,
 			EntitlementsErrorMapper: params.EntitlementsErrorMapper,
 
-			Groups:            params.Groups,
+			Groups:            groups,
 			GroupsErrorMapper: params.GroupsErrorMapper,
 
-			Resources:            params.Resources,
+			Resources:            resources,
 			ResourcesErrorMapper: params.ResourcesErrorMapper,
 		})), nil
 }

--- a/v1/entitlements_unimplemented.go
+++ b/v1/entitlements_unimplemented.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2024 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+)
+
+// unimplementedEntitlementsService represents a *Null Object* implementation of the the `EntitlementsService` interface.
+type unimplementedEntitlementsService struct{}
+
+func (s unimplementedEntitlementsService) ListEntitlements(ctx context.Context, params *resources.GetEntitlementsParams) ([]resources.EntitlementSchema, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedEntitlementsService) RawEntitlements(ctx context.Context) (string, error) {
+	return "", NewNotImplementedError("")
+}

--- a/v1/groups_unimplemented.go
+++ b/v1/groups_unimplemented.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2024 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+)
+
+// unimplementedGroupsService represents a *Null Object* implementation of the the `GroupsService` interface.
+type unimplementedGroupsService struct{}
+
+func (s unimplementedGroupsService) ListGroups(ctx context.Context, params *resources.GetGroupsParams) (*resources.PaginatedResponse[resources.Group], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) CreateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) GetGroup(ctx context.Context, groupId string) (*resources.Group, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) UpdateGroup(ctx context.Context, group *resources.Group) (*resources.Group, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) DeleteGroup(ctx context.Context, groupId string) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) GetGroupIdentities(ctx context.Context, groupId string, params *resources.GetGroupsItemIdentitiesParams) (*resources.PaginatedResponse[resources.Identity], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) PatchGroupIdentities(ctx context.Context, groupId string, identityPatches []resources.GroupIdentitiesPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) GetGroupRoles(ctx context.Context, groupId string, params *resources.GetGroupsItemRolesParams) (*resources.PaginatedResponse[resources.Role], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) PatchGroupRoles(ctx context.Context, groupId string, rolePatches []resources.GroupRolesPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) GetGroupEntitlements(ctx context.Context, groupId string, params *resources.GetGroupsItemEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedGroupsService) PatchGroupEntitlements(ctx context.Context, groupId string, entitlementPatches []resources.GroupEntitlementsPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}

--- a/v1/identities_unimplemented.go
+++ b/v1/identities_unimplemented.go
@@ -1,0 +1,69 @@
+// Copyright (C) 2024 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+)
+
+// unimplementedIdentitiesService represents a *Null Object* implementation of the the `IdentitiesService` interface.
+type unimplementedIdentitiesService struct{}
+
+func (s unimplementedIdentitiesService) ListIdentities(ctx context.Context, params *resources.GetIdentitiesParams) (*resources.PaginatedResponse[resources.Identity], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) CreateIdentity(ctx context.Context, identity *resources.Identity) (*resources.Identity, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) GetIdentity(ctx context.Context, identityId string) (*resources.Identity, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) UpdateIdentity(ctx context.Context, identity *resources.Identity) (*resources.Identity, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) DeleteIdentity(ctx context.Context, identityId string) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) GetIdentityGroups(ctx context.Context, identityId string, params *resources.GetIdentitiesItemGroupsParams) (*resources.PaginatedResponse[resources.Group], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) PatchIdentityGroups(ctx context.Context, identityId string, groupPatches []resources.IdentityGroupsPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) GetIdentityRoles(ctx context.Context, identityId string, params *resources.GetIdentitiesItemRolesParams) (*resources.PaginatedResponse[resources.Role], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) PatchIdentityRoles(ctx context.Context, identityId string, rolePatches []resources.IdentityRolesPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) GetIdentityEntitlements(ctx context.Context, identityId string, params *resources.GetIdentitiesItemEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentitiesService) PatchIdentityEntitlements(ctx context.Context, identityId string, entitlementPatches []resources.IdentityEntitlementsPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}

--- a/v1/identity_providers_unimplemented.go
+++ b/v1/identity_providers_unimplemented.go
@@ -1,0 +1,49 @@
+// Copyright (C) 2024 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+)
+
+// unimplementedIdentityProvidersService represents a *Null Object* implementation of the the `IdentityProvidersService` interface.
+type unimplementedIdentityProvidersService struct{}
+
+func (s unimplementedIdentityProvidersService) ListAvailableIdentityProviders(ctx context.Context, params *resources.GetAvailableIdentityProvidersParams) (*resources.PaginatedResponse[resources.AvailableIdentityProvider], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentityProvidersService) ListIdentityProviders(ctx context.Context, params *resources.GetIdentityProvidersParams) (*resources.PaginatedResponse[resources.IdentityProvider], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentityProvidersService) RegisterConfiguration(ctx context.Context, provider *resources.IdentityProvider) (*resources.IdentityProvider, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentityProvidersService) DeleteConfiguration(ctx context.Context, id string) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentityProvidersService) GetConfiguration(ctx context.Context, id string) (*resources.IdentityProvider, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedIdentityProvidersService) UpdateConfiguration(ctx context.Context, provider *resources.IdentityProvider) (*resources.IdentityProvider, error) {
+	return nil, NewNotImplementedError("")
+}

--- a/v1/resources_unimplemented.go
+++ b/v1/resources_unimplemented.go
@@ -1,0 +1,29 @@
+// Copyright (C) 2024 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+)
+
+// unimplementedResourcesService represents a *Null Object* implementation of the the `ResourcesService` interface.
+type unimplementedResourcesService struct{}
+
+func (s unimplementedResourcesService) ListResources(ctx context.Context, params *resources.GetResourcesParams) (*resources.PaginatedResponse[resources.Resource], error) {
+	return nil, NewNotImplementedError("")
+}

--- a/v1/roles_unimplemented.go
+++ b/v1/roles_unimplemented.go
@@ -1,0 +1,53 @@
+// Copyright (C) 2024 Canonical Ltd.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package v1
+
+import (
+	"context"
+
+	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
+)
+
+// unimplementedRolesService represents a *Null Object* implementation of the the `RolesService` interface.
+type unimplementedRolesService struct{}
+
+func (s unimplementedRolesService) ListRoles(ctx context.Context, params *resources.GetRolesParams) (*resources.PaginatedResponse[resources.Role], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedRolesService) CreateRole(ctx context.Context, role *resources.Role) (*resources.Role, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedRolesService) GetRole(ctx context.Context, roleId string) (*resources.Role, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedRolesService) UpdateRole(ctx context.Context, role *resources.Role) (*resources.Role, error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedRolesService) DeleteRole(ctx context.Context, roleId string) (bool, error) {
+	return false, NewNotImplementedError("")
+}
+
+func (s unimplementedRolesService) GetRoleEntitlements(ctx context.Context, roleId string, params *resources.GetRolesItemEntitlementsParams) (*resources.PaginatedResponse[resources.EntityEntitlement], error) {
+	return nil, NewNotImplementedError("")
+}
+
+func (s unimplementedRolesService) PatchRoleEntitlements(ctx context.Context, roleId string, entitlementPatches []resources.RoleEntitlementsPatchItem) (bool, error) {
+	return false, NewNotImplementedError("")
+}


### PR DESCRIPTION
If a `*Service` interface is not implemented then a panic will happen whenever we get a request for any of the corresponding endpoints. This PR fixes that by applying falling back to *Null Object* implementations of the `*Service` interfaces.

Fixes CSS-10645