### PR TITLE
fix: ignore auth for swagger endpoint

### DIFF
--- a/v1/authentication.go
+++ b/v1/authentication.go
@@ -18,6 +18,7 @@ package v1
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 )
@@ -79,4 +80,14 @@ func GetIdentityFromContext(ctx context.Context) (any, error) {
 // then pass it (as the HTTP request context) to the next HTTP handler.
 func ContextWithIdentity(ctx context.Context, identity any) context.Context {
 	return context.WithValue(ctx, authenticatedIdentityContextKey{}, identity)
+}
+
+// isAuthenticationRequired checks if the given request (identified by the URL)
+// should be authenticated.
+func isAuthenticationRequired(relativePath string) bool {
+	relativePath, _ = strings.CutSuffix(relativePath, "/")
+
+	// For now, the only endpoint that does not require authentication is
+	// `/swagger.json`. So, we can just return with a string comparison.
+	return relativePath != "/swagger.json"
 }

--- a/v1/authentication.go
+++ b/v1/authentication.go
@@ -52,6 +52,8 @@ func (b *ReBACAdminBackend) authenticationMiddleware() resources.MiddlewareFunc 
 	}
 }
 
+// authenticatedIdentityContextKey is the type-safe context key to be used to
+// store the identity of the request caller.
 type authenticatedIdentityContextKey struct{}
 
 // GetIdentityFromContext fetches authenticated identity of the caller from the

--- a/v1/core.go
+++ b/v1/core.go
@@ -119,14 +119,16 @@ func newReBACAdminBackendWithService(params ReBACAdminBackendParams, handler res
 
 // Handler returns HTTP handlers implementing the ReBAC Admin OpenAPI spec.
 func (b *ReBACAdminBackend) Handler(baseURL string) http.Handler {
+	baseURL, _ = strings.CutSuffix(baseURL, "/")
+	baseURL = baseURL + "/v1"
+
 	var middlewares []resources.MiddlewareFunc
 	if b.params.Authenticator != nil {
-		middlewares = append(middlewares, b.authenticationMiddleware())
+		middlewares = append(middlewares, b.authenticationMiddleware(baseURL))
 	}
 
-	baseURL, _ = strings.CutSuffix(baseURL, "/")
 	return resources.HandlerWithOptions(b.handler, resources.ChiServerOptions{
-		BaseURL:     baseURL + "/v1",
+		BaseURL:     baseURL,
 		Middlewares: middlewares,
 		ErrorHandlerFunc: func(w http.ResponseWriter, _ *http.Request, err error) {
 			writeErrorResponse(w, err)


### PR DESCRIPTION
This PR disables authentication for the `/swagger.json` endpoint.

Fixes CSS-10917