### PR TITLE
feat(error-response-mapper): update MapError to use the context

### DIFF
--- a/v1/authentication.go
+++ b/v1/authentication.go
@@ -46,7 +46,7 @@ func (b *ReBACAdminBackend) authenticationMiddleware(baseURL string) resources.M
 
 			identity, err := b.params.Authenticator.Authenticate(r)
 			if err != nil {
-				writeServiceErrorResponse(w, b.params.AuthenticatorErrorMapper, err)
+				writeServiceErrorResponse(r.Context(), w, b.params.AuthenticatorErrorMapper, err)
 				return
 			}
 			if identity == nil {

--- a/v1/authentication_test.go
+++ b/v1/authentication_test.go
@@ -16,6 +16,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -111,7 +112,7 @@ func TestContextualAuthenticatedIdentity_MiddlewareAndContext(t *testing.T) {
 		name               string
 		setupRequest       func() *http.Request
 		authenticatorFunc  func(r *http.Request) (any, error)
-		mapErrorFunc       func(error) *resources.Response
+		mapErrorFunc       func(context.Context, error) *resources.Response
 		nextHandler        func(c *qt.C, w http.ResponseWriter, r *http.Request)
 		expectedStatusCode int
 		expectedMessage    string
@@ -144,7 +145,7 @@ func TestContextualAuthenticatedIdentity_MiddlewareAndContext(t *testing.T) {
 		authenticatorFunc: func(r *http.Request) (any, error) {
 			return nil, errors.New("some error")
 		},
-		mapErrorFunc: func(err error) *resources.Response {
+		mapErrorFunc: func(ctx context.Context, err error) *resources.Response {
 			return &resources.Response{
 				Status:  999, // Some bizarre code
 				Message: "mapped error message",
@@ -184,7 +185,7 @@ func TestContextualAuthenticatedIdentity_MiddlewareAndContext(t *testing.T) {
 			var mockErrorMapper ErrorResponseMapper
 			if tt.mapErrorFunc != nil {
 				mapper := NewMockErrorResponseMapper(ctrl)
-				mapper.EXPECT().MapError(gomock.Any()).DoAndReturn(tt.mapErrorFunc)
+				mapper.EXPECT().MapError(gomock.Any(), gomock.Any()).DoAndReturn(tt.mapErrorFunc)
 				mockErrorMapper = mapper
 			}
 

--- a/v1/capabilities.go
+++ b/v1/capabilities.go
@@ -31,7 +31,7 @@ func (h handler) GetCapabilities(w http.ResponseWriter, req *http.Request) {
 	if h.Capabilities != nil {
 		capabilities, err = h.Capabilities.ListCapabilities(ctx)
 		if err != nil {
-			writeServiceErrorResponse(w, h.CapabilitiesErrorMapper, err)
+			writeServiceErrorResponse(ctx, w, h.CapabilitiesErrorMapper, err)
 			return
 		}
 	} else {

--- a/v1/capabilities_test.go
+++ b/v1/capabilities_test.go
@@ -160,7 +160,7 @@ func TestHandler_Capabilities_GetCapabilitiesFailure(t *testing.T) {
 	mockError := errors.New("test-error")
 
 	mockCapabilitiesService.EXPECT().ListCapabilities(gomock.Any()).Return(nil, mockError)
-	mockErrorResponseMapper.EXPECT().MapError(gomock.Eq(mockError)).Return(&mockErrorResponse)
+	mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Eq(mockError)).Return(&mockErrorResponse)
 
 	sut := handler{
 		Capabilities:            mockCapabilitiesService,

--- a/v1/entitlements.go
+++ b/v1/entitlements.go
@@ -28,7 +28,7 @@ func (h handler) GetEntitlements(w http.ResponseWriter, req *http.Request, param
 
 	entitlements, err := h.Entitlements.ListEntitlements(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.EntitlementsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.EntitlementsErrorMapper, err)
 		return
 	}
 
@@ -50,7 +50,7 @@ func (h handler) GetRawEntitlements(w http.ResponseWriter, req *http.Request) {
 
 	entitlementsRawString, err := h.Entitlements.RawEntitlements(ctx)
 	if err != nil {
-		writeServiceErrorResponse(w, h.EntitlementsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.EntitlementsErrorMapper, err)
 		return
 	}
 

--- a/v1/entitlements_test.go
+++ b/v1/entitlements_test.go
@@ -168,7 +168,7 @@ func TestHandler_Entitlements_ServiceBackendFailures(t *testing.T) {
 		tt := test
 		c.Run(tt.name, func(c *qt.C) {
 			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
-			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Any()).Return(&mockErrorResponse)
 
 			mockEntitlementsService := interfaces.NewMockEntitlementsService(ctrl)
 			tt.setupServiceMock(mockEntitlementsService)

--- a/v1/error.go
+++ b/v1/error.go
@@ -16,6 +16,7 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -121,7 +122,7 @@ func NewUnknownError(message string) error {
 type ErrorResponseMapper interface {
 	// MapError maps an error into a Response. If the method is unable to map the
 	// error (e.g., the error is unknown), it must return nil.
-	MapError(error) *resources.Response
+	MapError(context.Context, error) *resources.Response
 }
 
 // mapHandlerBadRequestError checks if the given error is an "Bad Request" error

--- a/v1/groups.go
+++ b/v1/groups.go
@@ -28,7 +28,7 @@ func (h handler) GetGroups(w http.ResponseWriter, req *http.Request, params reso
 
 	groups, err := h.Groups.ListGroups(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -61,7 +61,7 @@ func (h handler) PostGroups(w http.ResponseWriter, req *http.Request) {
 
 	result, err := h.Groups.CreateGroup(ctx, group)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -75,7 +75,7 @@ func (h handler) DeleteGroupsItem(w http.ResponseWriter, req *http.Request, id s
 
 	_, err := h.Groups.DeleteGroup(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h handler) GetGroupsItem(w http.ResponseWriter, req *http.Request, id stri
 
 	group, err := h.Groups.GetGroup(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (h handler) PutGroupsItem(w http.ResponseWriter, req *http.Request, id stri
 
 	result, err := h.Groups.UpdateGroup(ctx, group)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -129,7 +129,7 @@ func (h handler) GetGroupsItemEntitlements(w http.ResponseWriter, req *http.Requ
 
 	entitlements, err := h.Groups.GetGroupEntitlements(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h handler) PatchGroupsItemEntitlements(w http.ResponseWriter, req *http.Re
 
 	_, err = h.Groups.PatchGroupEntitlements(ctx, id, groupEntitlements.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (h handler) GetGroupsItemIdentities(w http.ResponseWriter, req *http.Reques
 
 	identities, err := h.Groups.GetGroupIdentities(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (h handler) PatchGroupsItemIdentities(w http.ResponseWriter, req *http.Requ
 
 	_, err = h.Groups.PatchGroupIdentities(ctx, id, groupIdentities.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -223,7 +223,7 @@ func (h handler) GetGroupsItemRoles(w http.ResponseWriter, req *http.Request, id
 
 	roles, err := h.Groups.GetGroupRoles(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 
@@ -256,7 +256,7 @@ func (h handler) PatchGroupsItemRoles(w http.ResponseWriter, req *http.Request, 
 
 	_, err = h.Groups.PatchGroupRoles(ctx, id, groupRoles.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.GroupsErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.GroupsErrorMapper, err)
 		return
 	}
 

--- a/v1/groups_test.go
+++ b/v1/groups_test.go
@@ -450,7 +450,7 @@ func TestHandler_Groups_ServiceBackendFailures(t *testing.T) {
 		tt := test
 		c.Run(tt.name, func(c *qt.C) {
 			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
-			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Any()).Return(&mockErrorResponse)
 
 			mockGroupsService := interfaces.NewMockGroupsService(ctrl)
 			tt.setupServiceMock(mockGroupsService)

--- a/v1/identities.go
+++ b/v1/identities.go
@@ -28,7 +28,7 @@ func (h handler) GetIdentities(w http.ResponseWriter, req *http.Request, params 
 
 	identities, err := h.Identities.ListIdentities(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -61,7 +61,7 @@ func (h handler) PostIdentities(w http.ResponseWriter, req *http.Request) {
 
 	result, err := h.Identities.CreateIdentity(ctx, identity)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -75,7 +75,7 @@ func (h handler) DeleteIdentitiesItem(w http.ResponseWriter, req *http.Request, 
 
 	_, err := h.Identities.DeleteIdentity(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h handler) GetIdentitiesItem(w http.ResponseWriter, req *http.Request, id 
 
 	identity, err := h.Identities.GetIdentity(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (h handler) PutIdentitiesItem(w http.ResponseWriter, req *http.Request, id 
 
 	result, err := h.Identities.UpdateIdentity(ctx, identity)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -129,7 +129,7 @@ func (h handler) GetIdentitiesItemEntitlements(w http.ResponseWriter, req *http.
 
 	entitlements, err := h.Identities.GetIdentityEntitlements(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h handler) PatchIdentitiesItemEntitlements(w http.ResponseWriter, req *htt
 
 	_, err = h.Identities.PatchIdentityEntitlements(ctx, id, identityEntitlements.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -176,7 +176,7 @@ func (h handler) GetIdentitiesItemGroups(w http.ResponseWriter, req *http.Reques
 
 	groups, err := h.Identities.GetIdentityGroups(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (h handler) PatchIdentitiesItemGroups(w http.ResponseWriter, req *http.Requ
 
 	_, err = h.Identities.PatchIdentityGroups(ctx, id, identityGroups.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -223,7 +223,7 @@ func (h handler) GetIdentitiesItemRoles(w http.ResponseWriter, req *http.Request
 
 	roles, err := h.Identities.GetIdentityRoles(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 
@@ -256,7 +256,7 @@ func (h handler) PatchIdentitiesItemRoles(w http.ResponseWriter, req *http.Reque
 
 	_, err = h.Identities.PatchIdentityRoles(ctx, id, identityRoles.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentitiesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentitiesErrorMapper, err)
 		return
 	}
 

--- a/v1/identities_test.go
+++ b/v1/identities_test.go
@@ -192,7 +192,7 @@ func TestHandler_Identities_ServiceBackendFailures(t *testing.T) {
 		tt := test
 		c.Run(tt.name, func(c *qt.C) {
 			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
-			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Any()).Return(&mockErrorResponse)
 
 			mockIdentityService := interfaces.NewMockIdentitiesService(ctrl)
 			tt.setupServiceMock(mockIdentityService)

--- a/v1/identity_providers.go
+++ b/v1/identity_providers.go
@@ -28,7 +28,7 @@ func (h handler) GetAvailableIdentityProviders(w http.ResponseWriter, req *http.
 
 	identityProviders, err := h.IdentityProviders.ListAvailableIdentityProviders(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -50,7 +50,7 @@ func (h handler) GetIdentityProviders(w http.ResponseWriter, req *http.Request, 
 
 	identityProviders, err := h.IdentityProviders.ListIdentityProviders(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -84,7 +84,7 @@ func (h handler) PostIdentityProviders(w http.ResponseWriter, req *http.Request)
 
 	result, err := h.IdentityProviders.RegisterConfiguration(ctx, identityProvider)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -98,7 +98,7 @@ func (h handler) DeleteIdentityProvidersItem(w http.ResponseWriter, req *http.Re
 
 	_, err := h.IdentityProviders.DeleteConfiguration(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -112,7 +112,7 @@ func (h handler) GetIdentityProvidersItem(w http.ResponseWriter, req *http.Reque
 
 	identityProvider, err := h.IdentityProviders.GetConfiguration(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 
@@ -138,7 +138,7 @@ func (h handler) PutIdentityProvidersItem(w http.ResponseWriter, req *http.Reque
 
 	result, err := h.IdentityProviders.UpdateConfiguration(ctx, identityProvider)
 	if err != nil {
-		writeServiceErrorResponse(w, h.IdentityProvidersErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.IdentityProvidersErrorMapper, err)
 		return
 	}
 

--- a/v1/identity_providers_test.go
+++ b/v1/identity_providers_test.go
@@ -282,7 +282,7 @@ func TestHandler_IdP_ServiceBackendFailures(t *testing.T) {
 		tt := test
 		c.Run(tt.name, func(c *qt.C) {
 			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
-			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Any()).Return(&mockErrorResponse)
 
 			mockIDPService := interfaces.NewMockIdentityProvidersService(ctrl)
 			tt.setupServiceMock(mockIDPService)

--- a/v1/resources.go
+++ b/v1/resources.go
@@ -28,7 +28,7 @@ func (h handler) GetResources(w http.ResponseWriter, req *http.Request, params r
 
 	res, err := h.Resources.ListResources(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.ResourcesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.ResourcesErrorMapper, err)
 		return
 	}
 

--- a/v1/resources_test.go
+++ b/v1/resources_test.go
@@ -142,7 +142,7 @@ func TestHandler_Resources_ServiceBackendFailures(t *testing.T) {
 		tt := test
 		c.Run(tt.name, func(c *qt.C) {
 			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
-			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Any()).Return(&mockErrorResponse)
 
 			mockResourcesService := interfaces.NewMockResourcesService(ctrl)
 			tt.setupServiceMock(mockResourcesService)

--- a/v1/response.go
+++ b/v1/response.go
@@ -16,6 +16,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 
@@ -90,10 +91,10 @@ func writeResponse(w http.ResponseWriter, status int, responseObject interface{}
 // mapping strategy.
 //
 // This method should never return nil response.
-func mapServiceErrorResponse(mapper ErrorResponseMapper, err error) *resources.Response {
+func mapServiceErrorResponse(ctx context.Context, mapper ErrorResponseMapper, err error) *resources.Response {
 	var response *resources.Response
 	if mapper != nil {
-		response = mapper.MapError(err)
+		response = mapper.MapError(ctx, err)
 	}
 
 	if response == nil {
@@ -104,8 +105,8 @@ func mapServiceErrorResponse(mapper ErrorResponseMapper, err error) *resources.R
 
 // writeServiceErrorResponse is a helper method that maps errors thrown by
 // services and writes them to the HTTP response stream.
-func writeServiceErrorResponse(w http.ResponseWriter, mapper ErrorResponseMapper, err error) {
-	response := mapServiceErrorResponse(mapper, err)
+func writeServiceErrorResponse(ctx context.Context, w http.ResponseWriter, mapper ErrorResponseMapper, err error) {
+	response := mapServiceErrorResponse(ctx, mapper, err)
 	writeResponse(w, response.Status, response)
 }
 

--- a/v1/response_test.go
+++ b/v1/response_test.go
@@ -16,6 +16,7 @@
 package v1
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -25,6 +26,8 @@ import (
 
 	"github.com/canonical/rebac-admin-ui-handlers/v1/resources"
 )
+
+type testCtxKey struct{}
 
 func TestMapErrorResponse(t *testing.T) {
 	c := qt.New(t)
@@ -141,6 +144,7 @@ func TestMapServiceErrorResponse(t *testing.T) {
 		name       string
 		initMapper func() ErrorResponseMapper
 		err        error
+		ctx        context.Context
 		expected   resources.Response
 	}{{
 		name: "nil mapper",
@@ -149,12 +153,13 @@ func TestMapServiceErrorResponse(t *testing.T) {
 			Status:  http.StatusInternalServerError,
 			Message: "Internal Server Error: foo",
 		},
+		ctx: context.Background(),
 	}, {
 		name: "non-nil mapper",
 		initMapper: func() ErrorResponseMapper {
 			mapper := NewMockErrorResponseMapper(ctrl)
 			mapper.EXPECT().
-				MapError(gomock.Any()).
+				MapError(gomock.Any(), gomock.Any()).
 				Return(&resources.Response{
 					Status:  999, // Some bizarre status code
 					Message: "foo",
@@ -166,6 +171,28 @@ func TestMapServiceErrorResponse(t *testing.T) {
 			Status:  999,
 			Message: "foo",
 		},
+		ctx: context.Background(),
+	}, {
+		name: "non-nil mapper using context",
+		initMapper: func() ErrorResponseMapper {
+			mapper := NewMockErrorResponseMapper(ctrl)
+			mapper.EXPECT().
+				MapError(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(ctx context.Context, err error) *resources.Response {
+					userID := ctx.Value(testCtxKey{}).(string)
+					return &resources.Response{
+						Status:  http.StatusTeapot, // Why not?
+						Message: "userID: " + userID,
+					}
+				})
+			return mapper
+		},
+		err: errors.New("baz"),
+		expected: resources.Response{
+			Status:  http.StatusTeapot,
+			Message: "userID: 42",
+		},
+		ctx: context.WithValue(context.Background(), testCtxKey{}, "42"),
 	},
 	}
 
@@ -177,7 +204,7 @@ func TestMapServiceErrorResponse(t *testing.T) {
 				mapper = tt.initMapper()
 			}
 
-			response := mapServiceErrorResponse(mapper, tt.err)
+			response := mapServiceErrorResponse(t.ctx, mapper, tt.err)
 			c.Assert(*response, qt.DeepEquals, tt.expected)
 		})
 	}

--- a/v1/roles.go
+++ b/v1/roles.go
@@ -28,7 +28,7 @@ func (h handler) GetRoles(w http.ResponseWriter, req *http.Request, params resou
 
 	roles, err := h.Roles.ListRoles(ctx, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -61,7 +61,7 @@ func (h handler) PostRoles(w http.ResponseWriter, req *http.Request) {
 
 	result, err := h.Roles.CreateRole(ctx, role)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -75,7 +75,7 @@ func (h handler) DeleteRolesItem(w http.ResponseWriter, req *http.Request, id st
 
 	_, err := h.Roles.DeleteRole(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -89,7 +89,7 @@ func (h handler) GetRolesItem(w http.ResponseWriter, req *http.Request, id strin
 
 	role, err := h.Roles.GetRole(ctx, id)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -115,7 +115,7 @@ func (h handler) PutRolesItem(w http.ResponseWriter, req *http.Request, id strin
 
 	result, err := h.Roles.UpdateRole(ctx, role)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -129,7 +129,7 @@ func (h handler) GetRolesItemEntitlements(w http.ResponseWriter, req *http.Reque
 
 	entitlements, err := h.Roles.GetRoleEntitlements(ctx, id, &params)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 
@@ -162,7 +162,7 @@ func (h handler) PatchRolesItemEntitlements(w http.ResponseWriter, req *http.Req
 
 	_, err = h.Roles.PatchRoleEntitlements(ctx, id, roleEntitlements.Patches)
 	if err != nil {
-		writeServiceErrorResponse(w, h.RolesErrorMapper, err)
+		writeServiceErrorResponse(ctx, w, h.RolesErrorMapper, err)
 		return
 	}
 

--- a/v1/roles_test.go
+++ b/v1/roles_test.go
@@ -330,7 +330,7 @@ func TestHandler_Roles_ServiceBackendFailures(t *testing.T) {
 		tt := test
 		c.Run(tt.name, func(c *qt.C) {
 			mockErrorResponseMapper := NewMockErrorResponseMapper(ctrl)
-			mockErrorResponseMapper.EXPECT().MapError(gomock.Any()).Return(&mockErrorResponse)
+			mockErrorResponseMapper.EXPECT().MapError(gomock.Any(), gomock.Any()).Return(&mockErrorResponse)
 
 			mockRoleService := interfaces.NewMockRolesService(ctrl)
 			tt.setupServiceMock(mockRoleService)


### PR DESCRIPTION
MapError takes in the context. This allows scenario where we want to have specific error logic using the context.
An example, needed to log security event about unauthorized access for JAAS is:

```go
type securityEventLogger struct{}

func (e *securityEventLogger) MapError(ctx context.Context, err error) *resources.Response {
	if errors.ErrorCode(err) == errors.CodeUnauthorized {
		identity := auth.SessionIdentityFromContext(ctx)
		logger.LogUnauthorizedAccess(ctx, identity, "attempted access to a restricted resource in the ReBAC admin API")
	}
	return nil
}
```

